### PR TITLE
Disable SSL verification of API endpoints

### DIFF
--- a/app/SupportedApps.php
+++ b/app/SupportedApps.php
@@ -58,6 +58,7 @@ abstract class SupportedApps
             'http_errors' => false, 
             'timeout' => 15, 
             'connect_timeout' => 15,
+            'verify' => false,
         ];
 
         $client = new Client($vars);


### PR DESCRIPTION
If a SSL certificate is invalid the API calls fail (e.g. when the service is using self-signed certs)