### PR TITLE
feat: Keep stored password when Enhanced App is updated

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -180,7 +180,12 @@ class ItemController extends Controller
         return view('items.edit', $data);
     }
 
-    public function storelogic($request, $id = null)
+    /**
+     * @param Request $request
+     * @param $id
+     * @return void
+     */
+    public function storelogic(Request $request, $id = null)
     {
         $application = Application::single($request->input('appid'));
         $validatedData = $request->validate([
@@ -225,6 +230,18 @@ class ItemController extends Controller
         }
 
         $config = Item::checkConfig($request->input('config'));
+
+        // Don't overwrite the stored password if it wasn't submitted when updating the item
+        if ($id !== null && strpos($config, '"password":null') !== false) {
+            $storedItem = Item::find($id);
+            $storedConfigObject = json_decode($storedItem->getAttribute('description'));
+
+            $configObject = json_decode($config);
+            $configObject->password = $storedConfigObject->password;
+
+            $config = json_encode($configObject);
+        }
+
         $current_user = User::currentUser();
         $request->merge([
             'description' => $config,


### PR DESCRIPTION
Right now when the user edits an Enhanced App and submits the form without filling in the password, the password will be overwritten.

After this patch if the user didn't submit the password field when editing an Enhanced App, the previous password will be kept in the database.