### PR TITLE
fix: Enable tag slug creation from CN characters

### DIFF
--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -4,13 +4,11 @@ namespace App\Http\Controllers;
 
 use App\Item;
 use App\User;
-use DB;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class TagController extends Controller
 {
@@ -68,7 +66,7 @@ class TagController extends Controller
             ]);
         }
 
-        $slug = str_slug($request->title, '-');
+        $slug = str_slug($request->title, '-', 'en_US');
 
         $current_user = User::currentUser();
 
@@ -140,7 +138,7 @@ class TagController extends Controller
             ]);
         }
 
-        $slug = str_slug($request->title, '-');
+        $slug = str_slug($request->title, '-', 'en_US');
         // set item type to tag
         $request->merge([
             'url' => $slug,

--- a/tests/Unit/helpers/SlugTest.php
+++ b/tests/Unit/helpers/SlugTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\helpers;
+
+use Tests\TestCase;
+
+class SlugTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function test_slug_returns_valid_tag_for_cn_characters_when_language_is_set_to_en_US()
+    {
+        $tag = str_slug('中文測試', '-', 'en_US');
+
+        $this->assertEquals('zhong-wen-ce-shi', $tag);
+    }
+}


### PR DESCRIPTION
- tag slugs creation returns empty string when only CN characters are provided.
- After this PR also Chinese tag names should be converted successfully to tag slugs.
- fixes #852