### PR TITLE
feat: Add tags as classes to items

### DIFF
--- a/app/Item.php
+++ b/app/Item.php
@@ -154,6 +154,23 @@ class Item extends Model
     }
 
     /**
+     * @return string
+     */
+    public function getTagClass(): string
+    {
+        $tags = $this->tags();
+        $slugs = [];
+
+        foreach ($tags as $tag) {
+            if ($tag->url) {
+                $slugs[] = 'tag-'.$tag->url;
+            }
+        }
+
+        return implode(' ', $slugs);
+    }
+
+    /**
      * @return BelongsToMany
      */
     public function parents(): BelongsToMany

--- a/resources/views/item.blade.php
+++ b/resources/views/item.blade.php
@@ -1,4 +1,4 @@
-                    <section class="item-container{{ $app->droppable }}" data-name="{{ $app->title }}" data-id="{{ $app->id }}">
+                    <section class="item-container{{ $app->droppable . ' ' . $app->getTagClass()}}" data-name="{{ $app->title }}" data-id="{{ $app->id }}">
                         <div class="item" style="background-color: {{ $app->colour }}">
                             <div class="app-icon-container">
                                 @if($app->icon)


### PR DESCRIPTION
- Add all tags as classes to the section element of the items
- Based on this CSS rules can be created that apply to elements that belong to a tag.
- Tags could now be used as categories with the right CSS

![tags-as-categories-css](https://user-images.githubusercontent.com/439392/208437907-444b036d-d8d7-485b-9bc9-11391bfdf97f.png)
