### PR TITLE
fix: Route titlecolour error

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,7 @@ use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\TagController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Request;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 /*


### PR DESCRIPTION
route named `titlecolour` always returns an error (status 500), because the wrong class was used.