### PR TITLE
Fix and add SVG support

### DIFF
--- a/app/Helper.php
+++ b/app/Helper.php
@@ -123,14 +123,16 @@ function isImage(string $file, string $extension): bool
         return false;
     }
 
-    $tempFileName = tempnam("/tmp", "image-check-");
+    $tempFileName = @tempnam("/tmp", "image-check-");
     $handle = fopen($tempFileName, "w");
 
     fwrite($handle, $file);
-
-    $size = @getimagesize($tempFileName);
-
     fclose($handle);
 
+    if ($extension == 'svg') {
+        return 'image/svg+xml' === mime_content_type($tempFileName);
+    }
+
+    $size = @getimagesize($tempFileName);
     return is_array($size) && str_starts_with($size['mime'], 'image');
 }


### PR DESCRIPTION
SVG images were not supported because the function getimagesize does not work with SVG.

Should resolve #1179 