### PR TITLE
Api import Items

### DIFF
--- a/app/Application.php
+++ b/app/Application.php
@@ -151,6 +151,17 @@ class Application extends Model
         return $app;
     }
 
+
+    /**
+     * @param $appName
+     * @return mixed|null
+     * @throws GuzzleException
+     */
+    public static function findApp($appName)
+    {
+        return self::where('name', $appName)->first()->appid;
+    }
+
     /**
      * @param $appid
      * @return mixed|null

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -207,6 +207,19 @@ class ItemController extends Controller
      */
     public static function storelogic(Request $request, $id = null): Item
     {
+        if ($request->input('optimistic')) {
+            $request->merge(['app' => Application::findApp($request->input('title'))]);
+            $request->merge((array)json_decode(ItemController::appload($request)));
+
+            # FIXME: I need to fix some param naming here to make it work
+            $request->merge([
+              /*  'pinned' => 1,*/
+              /*  'tags' => [0],*/
+              'icon' => $request->input('iconview'),
+              'appdescription' => $request->input('description'),
+            ]);
+        }
+
         $application = Application::single($request->input('appid'));
         $validatedData = $request->validate([
             'title' => 'required|max:255',
@@ -366,7 +379,7 @@ class ItemController extends Controller
      *
      * @throws GuzzleException
      */
-    public function appload(Request $request): ?string
+    public static function appload(Request $request): ?string
     {
         $output = [];
         $appid = $request->input('app');

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -16,6 +16,7 @@ class VerifyCsrfToken extends Middleware
         'order',
         'appload',
         'test_config',
+        'api/*',
         //'get_stats'
     ];
 }


### PR DESCRIPTION
Allows to import Items in an _optimistic_ way, to enable bulk Items import.
Under the hood it tries to match the Application from the Item title and fill all the details.

Usage:

```
curl -X POST 'http://localhost:8000/api/item' \
  --header 'Content-Type: application/json' \
  --header 'Accept: application/json' \
  --data-raw '{
  "title": "Jellyfin",
  "url": "http://jellyfin.lan",
  "tags": [
    0
  ],
  "pinned": "1",
  "optimistic": "true"
}'
```