### PR TITLE
Add Brave search engine to Homepage Search

### DIFF
--- a/lang/en/app.php
+++ b/lang/en/app.php
@@ -36,6 +36,7 @@ return array (
   'options.google' => 'Google',
   'options.ddg' => 'DuckDuckGo',
   'options.bing' => 'Bing',
+  'options.brave' => 'Brave',
   'options.qwant' => 'Qwant',
   'options.startpage' => 'StartPage',
   'options.yes' => 'Yes',

--- a/storage/app/searchproviders.yaml
+++ b/storage/app/searchproviders.yaml
@@ -19,6 +19,14 @@ bing:
    target: _blank
    query: q
 
+brave:
+   id: brave
+   url: https://search.brave.com/search
+   name: Brave
+   method: get
+   target: _blank
+   query: q
+
 ddg:
    id: ddg
    url: https://duckduckgo.com/


### PR DESCRIPTION
Hi, I'd like to add Brave search engine to the Homepage Search.  I haven't updated all of the `/lang/*/app.php` files to include the `'options.brave' => 'Brave',` line, just the english file, but this should get the base functionality into place. 