### PR TITLE
feat(icon-upload): proxy management

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -267,6 +267,11 @@ class ItemController extends Controller
                 ],
             ];
 
+            // Proxy management
+            if (isset(getenv('HTTPS_PROXY')) || isset(getenv('https_proxy'))) {
+                $options['proxy']['http'] = getenv('HTTPS_PROXY') ?: getenv('https_proxy');
+            }
+
             $file = $request->input('icon');
             $path_parts = pathinfo($file);
             if (!isset($path_parts['extension'])) {


### PR DESCRIPTION
Add proxy management for the icon upload.

In my current environment, I had to modify that part of the application to be able to download the icon.
Another solution could be to use an alternative to `file_get_contents`.